### PR TITLE
Update sample app CVE 2021 43138

### DIFF
--- a/OmnichannelE2VVReactNativeSampleApp/package-lock.json
+++ b/OmnichannelE2VVReactNativeSampleApp/package-lock.json
@@ -3700,8 +3700,9 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
     },
     "async": {
-      "version": "2.6.3",
-      "resolved": "",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "requires": {
         "lodash": "^4.17.14"
       }

--- a/OmnichannelE2VVReactNativeSampleApp/package-lock.json
+++ b/OmnichannelE2VVReactNativeSampleApp/package-lock.json
@@ -2905,9 +2905,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.20.51",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.51.tgz",
-          "integrity": "sha512-anVDMfReTatfH8GVmHmaTZOL0jeTLNZ9wK9SSrQS3tMmn4vUc+9fVWlUzAieuQefWDyWUz4Z3aqXxDgO1VsYjg=="
+          "version": "12.20.52",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.52.tgz",
+          "integrity": "sha512-cfkwWw72849SNYp3Zx0IcIs25vABmFh73xicxhCkTcvtZQeIez15PpwQN8fY3RD7gv1Wrxlc9MEtfMORZDEsGw=="
         }
       }
     },
@@ -2938,8 +2938,9 @@
       }
     },
     "@microsoft/omnichannel-voice-video-calling-react-native": {
-      "version": "file:microsoft-omnichannel-voice-video-calling-react-native-0.1.0-0.tgz",
-      "integrity": "sha512-ZcbUrzXVDE+aFg2KIIR5NyooOaQPFDCNrBv6Tfx5i++9if2NGXMOM7v3kiEw/t8VQh3lBaNQacNsx0x04jKk2w==",
+      "version": "0.1.0-main.fcc7a76",
+      "resolved": "https://registry.npmjs.org/@microsoft/omnichannel-voice-video-calling-react-native/-/omnichannel-voice-video-calling-react-native-0.1.0-main.fcc7a76.tgz",
+      "integrity": "sha512-lmGVTW9Mx/10oHyYObmTrJmFw2ocOt45dDUfBNFAiWbdmHhoMJ8HGCjSLgcXNT9czqEja384QJ+Ha7VEItBb6A==",
       "requires": {
         "@microsoft/omnichannel-chat-sdk": "^1.0.1-main.1082fd3",
         "ansi-regex": "^6.0.1",

--- a/OmnichannelE2VVReactNativeSampleApp/package.json
+++ b/OmnichannelE2VVReactNativeSampleApp/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@microsoft/omnichannel-voice-video-calling-react-native": "0.1.0-main.03e92a9",
+    "@microsoft/omnichannel-voice-video-calling-react-native": "0.1.0-main.fcc7a76",
     "@react-native/normalize-color": "^2.0.0",
     "react": "17.0.2",
     "react-native": "0.68.0",


### PR DESCRIPTION
update to latest version for EVV and audit fix 

https://www.npmjs.com/package/@microsoft/omnichannel-voice-video-calling-react-native

`elopezanaya  OmnichannelE2VVReactNativeSampleApp  ➜ (update-sample-app-cve-2021-43138  1)   14.18.1  ♥ 11:39  npm audit

                       === npm audit security report ===

found 0 vulnerabilities
 in 1300 scanned packages`

<img width="962" alt="image" src="https://user-images.githubusercontent.com/981914/168346781-c5b7dc63-aa21-491b-a2ee-33604dc054de.png">

<img width="974" alt="image" src="https://user-images.githubusercontent.com/981914/168347082-7695b543-a8ff-4547-86e3-00a7eefb1808.png">
