### PR TITLE
removing not longer necessary argument for Sample APP

### DIFF
--- a/OmnichannelE2VVReactNativeSampleApp/ios/OmnichannelE2VVReactNativeSampleApp/AppDelegate.m
+++ b/OmnichannelE2VVReactNativeSampleApp/ios/OmnichannelE2VVReactNativeSampleApp/AppDelegate.m
@@ -53,7 +53,7 @@ static void InitializeFlipper(UIApplication *application) {
 - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
 {
 #if DEBUG
-  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
+  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index"];
 #else
   return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
 #endif


### PR DESCRIPTION
PROBLEM

after the update to react-native 0.68, the Sample app was no longer compiling, due to the app delegate which wasn't compiling anymore due to an extra argument that was no longer necessary.

SOLUTION

Remove the extra argument

ACCEPTANCE CRITERIA

- Components should compile
- Sample APP should be back to the working state


evidence ->

<img width="1374" alt="Screen Shot 2022-05-16 at 4 59 40 PM" src="https://user-images.githubusercontent.com/981914/168701326-d9e25423-fa46-4e01-9e63-96eb9b95b519.png">